### PR TITLE
Change describe_parameters to get_parameters_by_path

### DIFF
--- a/pychamber/utils/ssm_parameter_store.py
+++ b/pychamber/utils/ssm_parameter_store.py
@@ -60,11 +60,11 @@ class SSMParameterStore(object):
         self._keys = {}
         self._substores = {}
 
-        paginator = self._client.get_paginator('describe_parameters')
+        paginator = self._client.get_paginator('get_parameters_by_path')
         pager = paginator.paginate(
-            ParameterFilters=[
-                dict(Key="Path", Option="Recursive", Values=[self._prefix])
-            ]
+            Path=self._prefix,
+            WithDecryption=True,
+            PaginationConfig={'PageSize': 10},
         )
 
         for page in pager:


### PR DESCRIPTION
DescribeParameters API endpoint is more prone to rate-limiting, switching to GetParametersByPath. See comment in chamber:

https://github.com/segmentio/chamber/blob/84f2d5daa2262125d78732988880fdcb4048aa1c/store/ssmstore.go#L440