### PR TITLE
Correctly capturing return codes from executed programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Optional: Use existing env variables if they exist rather than incoming SSM Para
 ## exec switch
 Calls a sub-process to execute the given program. Chamber expects that the given program call is available in the PATH or is a fully qualified location to the executable.
 
+Note: Chamber will capture the return result from the program which is executed and will return the result of the execution back to the shell.
+
 # Credits
 
 The following people / projects are credited for pychamber project.

--- a/pychamber/chamber.py
+++ b/pychamber/chamber.py
@@ -47,7 +47,8 @@ def main():
                 my_env[param] = store[ssm_param]
 
     my_command = args.exec
-    run_command(my_command, env = my_env)
+    result = run_command(my_command, env = my_env)
+    return result
 
 # run the main function only if this module is executed as the
 # main script. (if you import this as a module then nothing is executed)

--- a/pychamber/chamber.py
+++ b/pychamber/chamber.py
@@ -1,6 +1,6 @@
 import os
-import subprocess
 
+from pychamber.utils.execution_utils import run_command
 from pychamber.utils.ssm_parameter_store import SSMParameterStore
 from pychamber.utils.manage_args import (
     parse_exec,
@@ -47,7 +47,7 @@ def main():
                 my_env[param] = store[ssm_param]
 
     my_command = args.exec
-    subprocess.run(my_command, env = my_env)
+    run_command(my_command, env = my_env)
 
 # run the main function only if this module is executed as the
 # main script. (if you import this as a module then nothing is executed)

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -8,13 +8,7 @@ def run_command(command, env):
         Enable debug logging and raise errors.
     """
     logging.debug("Command: {}".format(command))
-    result = subprocess.run(command, env=env, shell=False, capture_output=True)
-    if result.stderr:
-        raise subprocess.CalledProcessError(
-                returncode = result.returncode,
-                cmd = result.args,
-                stderr = result.stderr
-                )
+    result = subprocess.run(command, env=env, shell=False, capture_output=False)
     if result.stdout:
-        logging.debug("Command Result: {}".format(result.stdout.decode('utf-8')))
-    return result
+        logging.debug(f"Command Result: {result.returncode=}")
+    return result.returncode

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -8,7 +8,7 @@ def c(command, env):
         Enable debug logging and raise errors.
     """
     logging.debug("Command: {}".format(command))
-    result = subprocess.run(command, env, shell=False, capture_output=True)
+    result = subprocess.run(command, env=env, shell=False, capture_output=True)
     if result.stderr:
         raise subprocess.CalledProcessError(
                 returncode = result.returncode,

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -5,7 +5,7 @@ import subprocess
 
 def run_command(command, env):
     """ Runs requested process with arguments.
-        Enable debug logging and raise errors.
+        Return: returncode of executed program.
     """
     logging.debug("Command: {}".format(command))
     result = subprocess.run(command, env=env, shell=False, capture_output=False)

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -1,0 +1,17 @@
+"""Utilities for pychamber."""
+
+import logging as log
+import subprocess
+
+def c(command):
+    log.debug("Command: {}".format(command))
+    result = subprocess.run(command, shell=True, capture_output=True)
+    if result.stderr:
+        raise subprocess.CalledProcessError(
+                returncode = result.returncode,
+                cmd = result.args,
+                stderr = result.stderr
+                )
+    if result.stdout:
+        log.debug("Command Result: {}".format(result.stdout.decode('utf-8')))
+    return result

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -9,6 +9,5 @@ def run_command(command, env):
     """
     logging.debug("Command: {}".format(command))
     result = subprocess.run(command, env=env, shell=False, capture_output=False)
-    if result.stdout:
-        logging.debug(f"Command Result: {result.returncode=}")
+
     return result.returncode

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -3,7 +3,7 @@
 import logging
 import subprocess
 
-def c(command, env):
+def run_command(command, env):
     """ Runs requested process with arguments.
         Enable debug logging and raise errors.
     """

--- a/pychamber/utils/execution_utils.py
+++ b/pychamber/utils/execution_utils.py
@@ -1,11 +1,14 @@
 """Utilities for pychamber."""
 
-import logging as log
+import logging
 import subprocess
 
-def c(command):
-    log.debug("Command: {}".format(command))
-    result = subprocess.run(command, shell=True, capture_output=True)
+def c(command, env):
+    """ Runs requested process with arguments.
+        Enable debug logging and raise errors.
+    """
+    logging.debug("Command: {}".format(command))
+    result = subprocess.run(command, env, shell=False, capture_output=True)
     if result.stderr:
         raise subprocess.CalledProcessError(
                 returncode = result.returncode,
@@ -13,5 +16,5 @@ def c(command):
                 stderr = result.stderr
                 )
     if result.stdout:
-        log.debug("Command Result: {}".format(result.stdout.decode('utf-8')))
+        logging.debug("Command Result: {}".format(result.stdout.decode('utf-8')))
     return result

--- a/pychamber/utils/manage_args.py
+++ b/pychamber/utils/manage_args.py
@@ -1,4 +1,4 @@
-# manage_args.py
+"""Process cli arguments via argparse with extensions."""
 
 import argparse
 from enum import Enum

--- a/pychamber/utils/ssm_parameter_store.py
+++ b/pychamber/utils/ssm_parameter_store.py
@@ -1,3 +1,5 @@
+"""Interact with AWS Parameter Store for secrets via boto3."""
+
 # Copyright (c) 2018 Bao Nguyen <b@nqbao.com>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pychamber"
-version = "0.1.1"
+version = "0.1.3"
 description = ""
 authors = ["Steve Clarke <84364906+s7clarke10@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Return codes were not being correctly captured for executed programs. Thus an executed program would always return 0 to the shell / executing program.

By passing on the return codes, the calling program can correctly capture and raise errors.